### PR TITLE
Update builder

### DIFF
--- a/builder/builder
+++ b/builder/builder
@@ -67,7 +67,6 @@ EOF
 
 chmod +x /start
 ln -nsf /start /exec
-rm -rf $app_dir
 mv $build_root $app_dir
 
 # Clean up


### PR DESCRIPTION
Preserving app_dir to allow a directory to be directly shared into /app rather than sending in a tarball of the app.
